### PR TITLE
CMS-4913 Reading and writing values of ValueType DateTime are inconsiste...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Bugfixes:
    then an error occurred when saving content (CMS-4910)
  - Java type conversion with LOCAL_DATE_TIME_FORMATTER and LOCAL_TIME_FORMATTER was using wrong
    hour format (1-24 instead of 0-23) (CMS-4913)
+ - Fixed styling when selecting controller for page template (CMS-4913)
 
 Features:
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/dropdown/dropdown.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/api/ui/selector/dropdown/dropdown.less
@@ -1,6 +1,13 @@
 .dropdown {
   position: relative;
-  display: block;
+  display: inline-block;
+  width: 100%;
+  max-width: 540px;
+  text-align: left;
+
+  input {
+    .input-glow();
+  }
 
   .input-icon {
     position: absolute;


### PR DESCRIPTION
...nt - causing saving to fail

Java type conversion with LOCAL_DATE_TIME_FORMATTER and LOCAL_TIME_FORMATTER was using wrong  hour format (1-24 instead of 0-23)

Style adjusted