### PR TITLE
CMS-4946 Live Edit - Performance problems caused by TreeGrid.postLoad

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -89,20 +89,24 @@ module app.browse {
             );
 
             api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, (item: api.ui.responsive.ResponsiveItem) => {
-                if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._240_360)) {
-                    this.getGrid().setColumns([nameColumn, orderColumn]);
-                } else if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._360_540)) {
-                    this.getGrid().setColumns([nameColumn, orderColumn, modifiedTimeColumn]);
-                } else {
-                    this.getGrid().setColumns([nameColumn, orderColumn, compareStatusColumn, modifiedTimeColumn]);
-                }
+                if (item.isRangeSizeChanged()) {
+                    if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._240_360)) {
+                        this.getGrid().setColumns([nameColumn, orderColumn]);
+                    } else if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._360_540)) {
+                        this.getGrid().setColumns([nameColumn, orderColumn, modifiedTimeColumn]);
+                    } else {
+                        this.getGrid().setColumns([nameColumn, orderColumn, compareStatusColumn, modifiedTimeColumn]);
+                    }
 
-                if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._540_720)) {
-                    modifiedTimeColumn.setMaxWidth(100);
-                    modifiedTimeColumn.setFormatter(DateTimeFormatter.formatNoTimestamp);
+                    if (item.isInRangeOrSmaller(api.ui.responsive.ResponsiveRanges._540_720)) {
+                        modifiedTimeColumn.setMaxWidth(100);
+                        modifiedTimeColumn.setFormatter(DateTimeFormatter.formatNoTimestamp);
+                    } else {
+                        modifiedTimeColumn.setMaxWidth(170);
+                        modifiedTimeColumn.setFormatter(DateTimeFormatter.format);
+                    }
                 } else {
-                    modifiedTimeColumn.setMaxWidth(170);
-                    modifiedTimeColumn.setFormatter(DateTimeFormatter.format);
+                    this.getGrid().resizeCanvas();
                 }
 
             });

--- a/modules/admin-ui/src/main/resources/web/admin/apps/module-manager/js/app/browse/ModuleTreeGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/module-manager/js/app/browse/ModuleTreeGrid.ts
@@ -53,6 +53,10 @@ module app.browse {
 
                     ]).prependClasses("module-grid")
             );
+
+            api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, (item: api.ui.responsive.ResponsiveItem) => {
+                this.getGrid().resizeCanvas();
+            });
         }
 
         private nameFormatter(row: number, cell: number, value: any, columnDef: any, node: TreeNode<Module>) {

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserItemsTreeGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserItemsTreeGrid.ts
@@ -72,6 +72,10 @@ module app.browse {
                 this.resetFilter();
             });
 
+            api.ui.responsive.ResponsiveManager.onAvailableSizeChanged(this, (item: api.ui.responsive.ResponsiveItem) => {
+                this.getGrid().resizeCanvas();
+            });
+
         }
 
         private nameFormatter(row: number, cell: number, value: any, columnDef: any, node: TreeNode<UserTreeGridItem>) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/grid/Grid.ts
@@ -354,6 +354,37 @@ module api.ui.grid {
             return this.slickGrid.getCellCssStyles(key);
         }
 
+        /*
+         Returns the DIV element matching class grid-canvas,
+         which contains every data row currently being rendered in the DOM.
+         */
+        getCanvasNode(): HTMLCanvasElement {
+            return this.slickGrid.getCanvasNode();
+        }
+
+        /*
+         Returns an object representing information about the grid's position on the page.
+         */
+        getGridPosition(): Slick.CellPosition {
+            return this.slickGrid.getGridPosition();
+        }
+
+        /*
+         If passed no arguments, returns an object that tells you the range of rows (by row number)
+         currently being rendered, as well as the left/right range of pixels currently rendered.
+         */
+        getRenderedRange(viewportTop?, viewportLeft?): Slick.Viewport {
+            return this.slickGrid.getRenderedRange(viewportTop, viewportLeft);
+        }
+
+        /*
+         Returns an object telling you which rows are currently being displayed on the screen,
+         and also the pixel offsets for left/right scrolling.
+         */
+        getViewport(viewportTop?, viewportLeft?): Slick.Viewport {
+            return this.slickGrid.getViewport(viewportTop, viewportLeft);
+        }
+
         subscribeOnSelectedRowsChanged(callback: (e, args) => void) {
             this.slickGrid.onSelectedRowsChanged.subscribe(callback);
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveItem.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/responsive/ResponsiveItem.ts
@@ -4,16 +4,21 @@ module api.ui.responsive {
 
         private element: api.dom.Element;
 
-        private rangeSize: ResponsiveRange; // Current layoutRange with class
+        private rangeSize: ResponsiveRange;    // Current layoutRange with class
 
-        private rangeValue: number;         // Range (width) value of the previous state
+        private oldRangeSize: ResponsiveRange; // Previous layoutRange with class
 
-        private handle: Function;           // Additional handler on update
+        private rangeValue: number;            // Range (width) value
+
+        private oldRangeValue: number;         // Range (width) value of the previous state
+
+        private handle: Function;              // Additional handler on update
 
         constructor(element: api.dom.Element, handler: (item: ResponsiveItem) => void = ((item: ResponsiveItem) => {
         })) {
             this.element = element;
             this.rangeValue = this.element.getEl().getWidthWithBorder();
+            this.oldRangeValue = this.rangeValue;
             this.handle = handler;
             this.fitToRange();
         }
@@ -40,12 +45,18 @@ module api.ui.responsive {
         update() {
             var newRangeValue = this.element.getEl().getWidthWithBorder();
             if (newRangeValue !== this.rangeValue) {
+                this.oldRangeValue = this.rangeValue;
+                this.oldRangeSize = this.rangeSize;
                 this.rangeValue = newRangeValue;
                 this.element.getEl().removeClass(this.rangeSize.getRangeClass());
                 this.fitToRange(); // update rangeSize
                 this.element.getEl().addClass(this.rangeSize.getRangeClass());
             }
             this.handle(this);     // Additional handler
+        }
+
+        isRangeSizeChanged(): boolean {
+            return this.rangeSize !== this.oldRangeSize;
         }
 
         setHandler(handler: (item: ResponsiveItem) => void = ((item: ResponsiveItem) => {
@@ -57,8 +68,16 @@ module api.ui.responsive {
             return this.rangeValue;
         }
 
+        getOldRangeValue(): number {
+            return this.oldRangeValue;
+        }
+
         getRangeSize(): ResponsiveRange {
             return this.rangeSize;
+        }
+
+        getOldRangeSize(): ResponsiveRange {
+            return this.oldRangeSize;
         }
 
         isInRange(range: ResponsiveRange): boolean {


### PR DESCRIPTION
Boost up the `TreeGrid.postLoad` method.
Replaced the jQUery code with the direct access from the SlickGrid
itself.
Added a single canvas resize call on resize for each grid.