### PR TITLE
CMS-5029 Content Wiz - When the content type form is empty - first meta ...

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/panel/PanelStrip.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/panel/PanelStrip.ts
@@ -10,8 +10,6 @@ module api.ui.panel {
 
         private offset: number = 0;
 
-        private hiddenHeader: number = 0;
-
         private panelShown: Panel = null;
 
         private panelShownListeners: {(event: PanelShownEvent):void}[] = [];
@@ -46,23 +44,11 @@ module api.ui.panel {
             if (header) {
                 var headerEl = new api.dom.H2El("panel-strip-panel-header");
                 headerEl.getEl().setInnerHtml(header);
-                headerEl.setVisible(false);
                 this.insertChild(headerEl, previousChildrenIndex);
             }
             this.panels.splice(index, 0, panel);
             this.headers.splice(index, 0, headerEl);
 
-            panel.onShown((event: api.dom.ElementShownEvent) => {
-                var panel = <Panel>event.getElement();
-                var panelIndex = this.getPanelIndex(panel);
-                if (panelIndex > 0) {
-                    if (this.panels[this.hiddenHeader].isVisible()) {
-                        this.headers[index].setVisible(true);
-                    } else {
-                        this.hiddenHeader += 1;
-                    }
-                }
-            });
             if (header) {
                 this.insertChild(panel, previousChildrenIndex + 1);
             } else {

--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
@@ -54,9 +54,6 @@
             font-size: 14px;
             font-family: @admin-font-family;
 
-            &:before {
-              content: "S";
-            }
           }
 
           &:hover {


### PR DESCRIPTION
...step looses its heading

Removed the code, that removes the headers, the content no longer have
the first header, if it's not the settings or security steps.
Removed `S` label from the site elements.