### PR TITLE
CMS-5058 Unnamed - Fix presentation of "Unnamed" in browse lists etc

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOptionViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/wizard/page/contextwindow/inspect/page/PageTemplateOptionViewer.ts
@@ -1,33 +1,22 @@
 module app.wizard.page.contextwindow.inspect.page {
 
-    export class PageTemplateOptionViewer extends api.ui.Viewer<PageTemplateOption> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PageTemplateOptionViewer extends api.ui.NamesAndIconViewer<PageTemplateOption> {
 
         constructor() {
             super();
-
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(option: PageTemplateOption) {
-            super.setObject(option);
+        resolveDisplayName(object: PageTemplateOption): string {
+            return !!object.getPageTemplate() ? object.getPageTemplate().getDisplayName() : "Automatic";
+        }
 
-            var pageTemplate = option.getPageTemplate();
-            if (pageTemplate) {
-                this.namesAndIconView.
-                    setMainName(pageTemplate.getDisplayName()).
-                    setSubName(pageTemplate.getPath().toString()).
-                    setIconClass("icon-newspaper icon-large");
-            }
-            else {
-                var defaultPageTemplateDisplayName = option.getPageModel().getDefaultPageTemplate().getDisplayName().toString();
-                this.namesAndIconView.
-                    setMainName("Automatic").
-                    setSubName("("+defaultPageTemplateDisplayName+")").
-                    setIconClass("icon-wand icon-large");
-            }
+        resolveSubName(object: PageTemplateOption, relativePath: boolean = false): string {
+            return !!object.getPageTemplate() ? object.getPageTemplate().getPath().toString() :
+                                                "(" + object.getPageModel().getDefaultPageTemplate().getDisplayName().toString() + ")";
+        }
+
+        resolveIconClass(object: PageTemplateOption): string {
+            return !!object.getPageTemplate() ? "icon-newspaper icon-large" : "icon-wand icon-large";
         }
 
         getPreferredHeight(): number {

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItemViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItemViewer.ts
@@ -1,85 +1,48 @@
 module app.browse {
 
-    export class UserTreeGridItemViewer extends api.ui.Viewer<UserTreeGridItem> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class UserTreeGridItemViewer extends api.ui.NamesAndIconViewer<UserTreeGridItem> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(gridItem:UserTreeGridItem, relativePath:boolean = false) {
-            super.setObject(gridItem);
-            this.namesAndIconView.setMainName(gridItem.getItemDisplayName());
-            this.namesAndIconView.setSubName(this.resolveSubName(gridItem, relativePath));
-
-            this.selectIconClass(gridItem);
+        resolveDisplayName(object: UserTreeGridItem): string {
+            return object.getItemDisplayName();
         }
 
-        private selectIconClass(item: UserTreeGridItem) {
-            var type: UserTreeGridItemType = item.getType();
-            switch (type) {
-            case UserTreeGridItemType.USER_STORE:
-            {
-                this.namesAndIconView.setIconClass("icon-address-book icon-large");
-                break;
-            }
-            case UserTreeGridItemType.PRINCIPAL:
-            {
-                if (item.getPrincipal().isRole()) {
-                    this.namesAndIconView.setIconClass("icon-shield icon-large");
-                } else if (item.getPrincipal().isUser()) {
-                    this.namesAndIconView.setIconClass("icon-user icon-large");
-                } else if (item.getPrincipal().isGroup()) {
-                    this.namesAndIconView.setIconClass("icon-users icon-large");
-                }
-                break;
-            }
-            case UserTreeGridItemType.GROUPS:
-            {
-                this.namesAndIconView.setIconClass("icon-folder icon-large");
-                break;
-            }
-            case UserTreeGridItemType.ROLES:
-            {
-                this.namesAndIconView.setIconClass("icon-folder icon-large");
-                break;
-            }
-            case UserTreeGridItemType.USERS:
-            {
-                this.namesAndIconView.setIconClass("icon-folder icon-large");
-                break;
-            }
-            }
+        resolveSubName(object: UserTreeGridItem, relativePath: boolean = false): string {
 
-        }
-
-        private resolveSubName(gridItem:UserTreeGridItem, relativePath:boolean):string {
-            var itemType = gridItem.getType();
-            switch (itemType) {
+            switch (object.getType()) {
                 case UserTreeGridItemType.USER_STORE:
-                {
-                    return ('/' + gridItem.getUserStore().getKey().toString());
-                }
+                    return ('/' + object.getUserStore().getKey().toString());
                 case UserTreeGridItemType.PRINCIPAL:
-                {
-                    if (relativePath) {
-                        return gridItem.getPrincipal().getKey().getId();
-                    } else {
-                        return gridItem.getPrincipal().getKey().toPath();
-                    }
-                }
+                    return relativePath ? object.getPrincipal().getKey().getId() :
+                                          object.getPrincipal().getKey().toPath();
                 default:
-                {
-                    return gridItem.getItemDisplayName().toLocaleLowerCase();
-                }
+                    return object.getItemDisplayName().toLocaleLowerCase();
             }
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveIconClass(object: UserTreeGridItem): string {
+
+            switch (object.getType()) {
+                case UserTreeGridItemType.USER_STORE:
+                    return "icon-address-book icon-large";
+                case UserTreeGridItemType.PRINCIPAL:
+                    if (object.getPrincipal().isRole()) {
+                        return "icon-shield icon-large";
+                    } else if (object.getPrincipal().isGroup()) {
+                        return "icon-users icon-large";
+                    } else { // object.getPrincipal().isUser()
+                        return "icon-user icon-large";
+                    }
+                case UserTreeGridItemType.GROUPS:
+                    return "icon-folder icon-large";
+                case UserTreeGridItemType.ROLES:
+                    return "icon-folder icon-large";
+                default: // UserTreeGridItemType.USERS:
+                    return "icon-folder icon-large";
+            }
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/NamesView.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/NamesView.ts
@@ -21,7 +21,7 @@ module api.app {
         }
 
         setMainName(value: string): NamesView {
-            this.mainNameEl.setHtml(value);
+            this.mainNameEl.getEl().setText(value);
             if (this.addTitleAttribute) {
                 this.mainNameEl.getEl().setAttribute("title", value);
             }
@@ -29,7 +29,7 @@ module api.app {
         }
 
         setSubName(value: string, title?: string): NamesView {
-            this.subNameEl.setHtml(value);
+            this.subNameEl.getEl().setText(value);
             if (this.addTitleAttribute) {
                 this.subNameEl.getEl().setAttribute("title", title || value);
             }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/app/wizard/WizardHeaderWithDisplayNameAndName.ts
@@ -141,7 +141,7 @@ module api.app.wizard {
         }
 
         setPath(value: string) {
-            this.pathEl.getEl().setInnerHtml(value);
+            this.pathEl.getEl().setText(value);
             this.pathEl.getEl().setAttribute('title', value);
             if (value) {
                 this.pathEl.show();

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentPath.ts
@@ -100,9 +100,8 @@ module api.content {
             var prettyElements: string[] = [];
             this.elements.forEach((element: string) => {
                 if (ContentName.fromString(element).isUnnamed()) {
-                    prettyElements.push(ContentUnnamed.PRETTY_UNNAMED);
-                }
-                else {
+                    prettyElements.push("<" + ContentUnnamed.PRETTY_UNNAMED + ">");
+                } else {
                     prettyElements.push(element);
                 }
             });

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatusViewer.ts
@@ -1,76 +1,59 @@
 module api.content {
 
-    export class ContentSummaryAndCompareStatusViewer extends api.ui.Viewer<ContentSummaryAndCompareStatus> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ContentSummaryAndCompareStatusViewer extends api.ui.NamesAndIconViewer<ContentSummaryAndCompareStatus> {
 
         constructor() {
             super("content-summary-and-compare-status-viewer");
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).
-                build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(contentSummaryAndCompareStatus: ContentSummaryAndCompareStatus, relativePath: boolean = false) {
-            super.setObject(contentSummaryAndCompareStatus);
+        resolveDisplayName(object: ContentSummaryAndCompareStatus): string {
+            var contentSummary = object.getContentSummary(),
+                uploadItem = object.getUploadItem();
 
-            var contentSummary = contentSummaryAndCompareStatus.getContentSummary();
-            var uploadItem = contentSummaryAndCompareStatus.getUploadItem();
+            if (contentSummary) {
+                return contentSummary.getDisplayName();
+            } else if (uploadItem) {
+                return uploadItem.getName();
+            }
 
-            var subName,
-                subTitle,
-                displayName,
-                iconUrl;
+            return "";
+        }
 
-            if (!!contentSummary) {
-                iconUrl = new ContentIconUrlResolver().
-                    setContent(contentSummary).
-                    setCrop(false).resolve();
+        resolveSubName(object: ContentSummaryAndCompareStatus, relativePath: boolean = false): string {
+            var contentSummary = object.getContentSummary(),
+                uploadItem = object.getUploadItem();
 
-                this.namesAndIconView.setIconUrl(iconUrl);
-
-                displayName = contentSummary.getDisplayName();
-                subName = this.resolveSubName(contentSummary, relativePath);
-                subTitle = contentSummary.getPath().toString();
-
+            if (contentSummary) {
                 this.toggleClass("invalid", !contentSummary.isValid());
-            } else if (!!uploadItem) {
-                this.namesAndIconView.setIconClass('icon-file-upload2');
 
-                displayName = uploadItem.getName();
-                subName = uploadItem.getName();
+                var contentName = contentSummary.getName();
+                if (relativePath) {
+                    return !contentName.isUnnamed() ? contentName.toString() :
+                                                      api.ui.NamesAndIconViewer.EMPTY_SUB_NAME;
+                } else {
+                    return !contentName.isUnnamed() ? contentSummary.getPath().toString() :
+                                                      ContentPath.fromParent(contentSummary.getPath().getParentPath(),
+                                                                             api.ui.NamesAndIconViewer.EMPTY_SUB_NAME).toString();
+                }
+            } else if (uploadItem) {
+                return uploadItem.getName();
             }
 
-            this.namesAndIconView.setMainName(displayName).
-                setSubName(subName, subTitle);
-
+            return "";
         }
 
-        private resolveSubName(content: ContentSummary, relativePath: boolean): string {
-
-            var contentName = content.getName();
-            if (relativePath) {
-                if (contentName.isUnnamed()) {
-                    return ContentUnnamed.PRETTY_UNNAMED;
-                }
-                else {
-                    return content.getName().toString()
-                }
-            }
-            else {
-                if (contentName.isUnnamed()) {
-                    var parentPath = content.getPath().getParentPath();
-                    return ContentPath.fromParent(parentPath, ContentUnnamed.PRETTY_UNNAMED).toString();
-                }
-                else {
-                    return content.getPath().toString();
-                }
-            }
+        resolveSubTitle(object: ContentSummaryAndCompareStatus): string {
+            var contentSummary = object.getContentSummary();
+            return !!contentSummary ? contentSummary.getPath().toString() : "";
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveIconClass(object: ContentSummaryAndCompareStatus): string {
+            return !!object.getUploadItem() ? "icon-file-upload2" : "";
+        }
+
+        resolveIconUrl(object: ContentSummaryAndCompareStatus): string {
+            var contentSummary = object.getContentSummary();
+            return !!contentSummary ? new ContentIconUrlResolver().setContent(contentSummary).setCrop(false).resolve() : "";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
@@ -1,53 +1,34 @@
 module api.content {
 
-    export class ContentSummaryViewer extends api.ui.Viewer<ContentSummary> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ContentSummaryViewer extends api.ui.NamesAndIconViewer<ContentSummary> {
 
         constructor() {
             super("content-summary-viewer");
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).
-                build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(content: ContentSummary, relativePath: boolean = false) {
-            super.setObject(content);
-            var subName = this.resolveSubName(content, relativePath);
-            var iconUrl = new ContentIconUrlResolver().
-                setContent(content).
-                setCrop(false).resolve();
-            this.namesAndIconView.setMainName(content.getDisplayName()).
-                setSubName(subName, content.getPath().toString()).
-                setIconUrl(iconUrl);
-            this.toggleClass("invalid", !content.isValid());
+        resolveDisplayName(object: ContentSummary): string {
+            this.toggleClass("invalid", !object.isValid());
+            return object.getDisplayName();
         }
 
-        private resolveSubName(content: ContentSummary, relativePath: boolean): string {
-
-            var contentName = content.getName();
+        resolveSubName(object: ContentSummary, relativePath: boolean = false): string {
+            var contentName = object.getName();
             if (relativePath) {
-                if (contentName.isUnnamed()) {
-                    return ContentUnnamed.PRETTY_UNNAMED;
-                }
-                else {
-                    return content.getName().toString()
-                }
-            }
-            else {
-                if (contentName.isUnnamed()) {
-                    var parentPath = content.getPath().getParentPath();
-                    return ContentPath.fromParent(parentPath, ContentUnnamed.PRETTY_UNNAMED).toString();
-                }
-                else {
-                    return content.getPath().toString();
-                }
+                return !contentName.isUnnamed() ? object.getName().toString() :
+                                                  api.ui.NamesAndIconViewer.EMPTY_SUB_NAME;
+            } else {
+                return !contentName.isUnnamed() ? object.getPath().toString() :
+                                                  ContentPath.fromParent(object.getPath().getParentPath(),
+                                                                         api.ui.NamesAndIconViewer.EMPTY_SUB_NAME).toString();
             }
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubTitle(object: ContentSummary): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconUrl(object: ContentSummary): string {
+            return new ContentIconUrlResolver().setContent(object).setCrop(false).resolve();
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentVersionViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentVersionViewer.ts
@@ -21,11 +21,6 @@ module api.content {
                                               contentVersion.displayName).
                 setSubName(contentVersion.comment);
         }
-
-        getPreferredHeight(): number {
-            return 50;
-        }
-
     }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorViewer.ts
@@ -1,24 +1,21 @@
 module api.content.form.inputtype.image {
 
-    export class ImageSelectorViewer extends api.ui.Viewer<ImageSelectorDisplayValue> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ImageSelectorViewer extends api.ui.NamesAndIconViewer<ImageSelectorDisplayValue> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(value: ImageSelectorDisplayValue) {
-            super.setObject(value);
-            this.namesAndIconView.setMainName(value.getDisplayName()).
-                setSubName(value.getPath()).
-                setIconUrl(value.getImageUrl() + '?crop=false');
+        resolveDisplayName(object: ImageSelectorDisplayValue): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: ImageSelectorDisplayValue, relativePath: boolean = false): string {
+            return object.getPath();
+        }
+
+        resolveIconUrl(object: ImageSelectorDisplayValue): string {
+            return object.getImageUrl() + "?crop=false";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageDescriptorViewer.ts
@@ -1,27 +1,22 @@
 module api.content.page {
 
-    export class PageDescriptorViewer extends  api.ui.Viewer<PageDescriptor> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PageDescriptorViewer extends api.ui.NamesAndIconViewer<PageDescriptor> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder()
-                .setSize(api.app.NamesAndIconViewSize.small).build();
-            this.namesAndIconView.setIconClass('icon-file icon-large');
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(desriptor: PageDescriptor) {
-            super.setObject(desriptor);
-            this.namesAndIconView.setMainName(desriptor.getDisplayName()).
-                setSubName(desriptor.getKey().toString());
+        resolveDisplayName(object: PageDescriptor): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: PageDescriptor, relativePath: boolean = false): string {
+            return object.getKey().toString();
         }
 
+        resolveIconClass(object: PageDescriptor): string {
+            return "icon-file icon-large";
+        }
     }
 
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageTemplateViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/PageTemplateViewer.ts
@@ -1,24 +1,21 @@
 module api.content.page {
 
-    export class PageTemplateViewer extends api.ui.Viewer<PageTemplate> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PageTemplateViewer extends api.ui.NamesAndIconViewer<PageTemplate> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.namesAndIconView.setIconClass("icon-newspaper icon-large");
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(pageTemplate: PageTemplate) {
-            super.setObject(pageTemplate);
-            this.namesAndIconView.setMainName(pageTemplate.getDisplayName()).
-                setSubName(pageTemplate.getController().toString());
+        resolveDisplayName(object: PageTemplate): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: PageTemplate, relativePath: boolean = false): string {
+            return object.getController().toString();
+        }
+
+        resolveIconClass(object: PageTemplate): string {
+            return "icon-newspaper icon-large";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/region/LayoutDescriptorViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/region/LayoutDescriptorViewer.ts
@@ -1,25 +1,21 @@
 module api.content.page.region {
 
-    export class LayoutDescriptorViewer extends api.ui.Viewer<LayoutDescriptor> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class LayoutDescriptorViewer extends api.ui.NamesAndIconViewer<LayoutDescriptor> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).build();
-            this.namesAndIconView.setIconClass('icon-insert-template icon-large');
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(layoutDescriptor: LayoutDescriptor) {
-            super.setObject(layoutDescriptor);
-            this.namesAndIconView.setMainName(layoutDescriptor.getDisplayName()).
-                setSubName(layoutDescriptor.getKey().toString());
+        resolveDisplayName(object: LayoutDescriptor): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: LayoutDescriptor, relativePath: boolean = false): string {
+            return object.getKey().toString();
+        }
+
+        resolveIconClass(object: LayoutDescriptor): string {
+            return "icon-insert-template icon-large";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/region/PartDescriptorViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/page/region/PartDescriptorViewer.ts
@@ -1,24 +1,21 @@
 module api.content.page.region {
 
-    export class PartDescriptorViewer extends api.ui.Viewer<PartDescriptor> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PartDescriptorViewer extends api.ui.NamesAndIconViewer<PartDescriptor> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build()
-                .setIconClass("icon-puzzle icon-large");
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(partDescriptor: PartDescriptor) {
-            super.setObject(partDescriptor);
-            this.namesAndIconView.setMainName(partDescriptor.getDisplayName()).
-                setSubName(partDescriptor.getKey().toString());
+        resolveDisplayName(object: PartDescriptor): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: PartDescriptor, relativePath: boolean = false): string {
+            return object.getKey().toString();
+        }
+
+        resolveIconClass(object: PartDescriptor): string {
+            return "icon-puzzle icon-large";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionComponentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/RegionComponentViewer.ts
@@ -1,24 +1,21 @@
 module api.liveedit {
 
-    export class RegionComponentViewer extends api.ui.Viewer<api.content.page.region.Region> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class RegionComponentViewer extends api.ui.NamesAndIconViewer<api.content.page.region.Region> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(region: api.content.page.region.Region) {
-            super.setObject(region);
-            this.namesAndIconView.setMainName(region.getName().toString()).
-                setSubName(region.getPath().toString()).
-                setIconClass('live-edit-font-icon-region');
+        resolveDisplayName(object: api.content.page.region.Region): string {
+            return object.getName().toString();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: api.content.page.region.Region, relativePath: boolean = false): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconClass(object: api.content.page.region.Region): string {
+            return "live-edit-font-icon-region";
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImageComponentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/image/ImageComponentViewer.ts
@@ -1,24 +1,21 @@
 module api.liveedit.image {
 
-    export class ImageComponentViewer extends api.ui.Viewer<api.content.page.region.ImageComponent> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ImageComponentViewer extends api.ui.NamesAndIconViewer<api.content.page.region.ImageComponent> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(imageComponent: api.content.page.region.ImageComponent) {
-            super.setObject(imageComponent);
-            this.namesAndIconView.setMainName(imageComponent.getName() ? imageComponent.getName().toString() : "").
-                setSubName(imageComponent.getPath().toString()).
-                setIconClass('live-edit-font-icon-image');
+        resolveDisplayName(object: api.content.page.region.ImageComponent): string {
+            return !!object.getName() ? object.getName().toString() : "";
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: api.content.page.region.ImageComponent, relativePath: boolean = false): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconClass(object: api.content.page.region.ImageComponent): string {
+            return "live-edit-font-icon-image";
         }
 
     }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutComponentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/layout/LayoutComponentViewer.ts
@@ -1,24 +1,21 @@
 module api.liveedit.layout {
 
-    export class LayoutComponentViewer extends api.ui.Viewer<api.content.page.region.LayoutComponent> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class LayoutComponentViewer extends api.ui.NamesAndIconViewer<api.content.page.region.LayoutComponent> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(layoutComponent: api.content.page.region.LayoutComponent) {
-            super.setObject(layoutComponent);
-            this.namesAndIconView.setMainName(layoutComponent.getName() ? layoutComponent.getName().toString() : "").
-                setSubName(layoutComponent.getPath().toString()).
-                setIconClass('live-edit-font-icon-layout');
+        resolveDisplayName(object: api.content.page.region.LayoutComponent): string {
+            return !!object.getName() ? object.getName().toString() : "";
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: api.content.page.region.LayoutComponent, relativePath: boolean = false): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconClass(object: api.content.page.region.LayoutComponent): string {
+            return "live-edit-font-icon-layout";
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/part/PartComponentViewer.ts
@@ -1,24 +1,21 @@
 module api.liveedit.part {
 
-    export class PartComponentViewer extends api.ui.Viewer<api.content.page.region.PartComponent> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PartComponentViewer extends api.ui.NamesAndIconViewer<api.content.page.region.PartComponent> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(partComponent: api.content.page.region.PartComponent) {
-            super.setObject(partComponent);
-            this.namesAndIconView.setMainName(partComponent.getName() ? partComponent.getName().toString() : "").
-                setSubName(partComponent.getPath().toString()).
-                setIconClass('live-edit-font-icon-part');
+        resolveDisplayName(object: api.content.page.region.PartComponent): string {
+            return !!object.getName() ? object.getName().toString() : "";
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: api.content.page.region.PartComponent, relativePath: boolean = false): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconClass(object: api.content.page.region.PartComponent): string {
+            return "live-edit-font-icon-part";
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/liveedit/text/TextComponentViewer.ts
@@ -1,25 +1,21 @@
 module api.liveedit.text {
 
-    export class TextComponentViewer extends api.ui.Viewer<api.content.page.region.TextComponent> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class TextComponentViewer extends api.ui.NamesAndIconViewer<api.content.page.region.TextComponent> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(textComponent: api.content.page.region.TextComponent) {
-            super.setObject(textComponent);
-            this.namesAndIconView.setMainName(textComponent.getText()).
-                setSubName(textComponent.getPath().toString()).
-                setIconClass('live-edit-font-icon-text');
-            return this;
+        resolveDisplayName(object: api.content.page.region.TextComponent): string {
+            return object.getText();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: api.content.page.region.TextComponent, relativePath: boolean = false): string {
+            return object.getPath().toString();
+        }
+
+        resolveIconClass(object: api.content.page.region.TextComponent): string {
+            return "live-edit-font-icon-text";
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/module/ModuleViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/module/ModuleViewer.ts
@@ -1,24 +1,21 @@
 module api.module {
 
-    export class ModuleViewer extends api.ui.Viewer<Module> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ModuleViewer extends api.ui.NamesAndIconViewer<Module> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(moduleObj: Module) {
-            super.setObject(moduleObj);
-            this.namesAndIconView.setMainName(moduleObj.getDisplayName()).
-                setSubName(moduleObj.getName()).
-                setIconClass("icon-puzzle icon-large");
+        resolveDisplayName(object: Module): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: Module, relativePath: boolean = false): string {
+            return object.getName();
+        }
+
+        resolveIconClass(object: Module): string {
+            return "icon-puzzle icon-large";
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeSummaryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/schema/content/ContentTypeSummaryViewer.ts
@@ -1,27 +1,24 @@
 module api.schema.content {
 
-    export class ContentTypeSummaryViewer extends api.ui.Viewer<ContentTypeSummary> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class ContentTypeSummaryViewer extends api.ui.NamesAndIconViewer<ContentTypeSummary> {
 
         private contentTypeIconUrlResolver: ContentTypeIconUrlResolver;
 
         constructor() {
             super();
             this.contentTypeIconUrlResolver = new ContentTypeIconUrlResolver();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(api.app.NamesAndIconViewSize.small).build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(contentType: ContentTypeSummary) {
-            super.setObject(contentType);
-            this.namesAndIconView.setMainName(contentType.getDisplayName()).
-                setSubName(contentType.getName()).
-                setIconUrl(this.contentTypeIconUrlResolver.resolve(contentType));
+        resolveDisplayName(object: ContentTypeSummary): string {
+            return object.getDisplayName();
         }
 
-        getPreferredHeight(): number {
-            return 50;
+        resolveSubName(object: ContentTypeSummary, relativePath: boolean = false): string {
+            return object.getName();
+        }
+
+        resolveIconUrl(object: ContentTypeSummary): string {
+            return this.contentTypeIconUrlResolver.resolve(object);
         }
     }
 }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/NamesAndIconViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/NamesAndIconViewer.ts
@@ -1,0 +1,67 @@
+module api.ui {
+
+    /**
+     * A parent class capable of viewing a given object with names and icon.
+     */
+    export class NamesAndIconViewer<OBJECT> extends api.ui.Viewer<OBJECT> {
+
+        static EMPTY_DISPLAY_NAME: string = "<Display Name>";
+        static EMPTY_SUB_NAME: string     = "<name>";
+
+        private namesAndIconView: api.app.NamesAndIconView;
+
+        constructor(className?: string, size: api.app.NamesAndIconViewSize = api.app.NamesAndIconViewSize.small) {
+            super(className);
+            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().setSize(size).build();
+        }
+
+        setObject(object: OBJECT, relativePath: boolean = false) {
+            super.setObject(object);
+
+            var displayName = this.resolveDisplayName(object) || NamesAndIconViewer.EMPTY_DISPLAY_NAME,
+                subName     = this.resolveSubName(object, relativePath) || NamesAndIconViewer.EMPTY_SUB_NAME,
+                subTitle    = this.resolveSubTitle(object),
+                iconClass   = this.resolveIconClass(object),
+                iconUrl     = this.resolveIconUrl(object);
+
+            this.namesAndIconView.setMainName(displayName).
+                                  setSubName(subName, subTitle).
+                                  setIconClass(iconClass);
+            if (!!iconUrl) {
+                this.namesAndIconView.setIconUrl(iconUrl);
+            }
+
+            this.render();
+        }
+
+        resolveDisplayName(object: OBJECT): string {
+            return "";
+        }
+
+        resolveSubName(object: OBJECT, relativePath: boolean = false): string {
+            return "";
+        }
+
+        resolveSubTitle(object: OBJECT): string {
+            return "";
+        }
+
+        resolveIconClass(object: OBJECT): string {
+            return "";
+        }
+
+        resolveIconUrl(object: OBJECT): string {
+            return "";
+        }
+
+        getPreferredHeight(): number {
+            return 50;
+        }
+
+        doRender() {
+            this.removeChildren();
+            this.appendChild(this.namesAndIconView);
+            return true;
+        }
+    }
+}

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/_module.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/_module.ts
@@ -18,3 +18,4 @@
 ///<reference path='RadioGroup.ts' />
 ///<reference path='Checkbox.ts' />
 ///<reference path='DragHelper.ts' />
+///<reference path='NamesAndIconViewer.ts' />

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/PrincipalViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/PrincipalViewer.ts
@@ -1,53 +1,35 @@
 module api.ui.security {
 
     import Principal = api.security.Principal;
-    import PrincipalKey = api.security.PrincipalKey;
     import PrincipalType = api.security.PrincipalType;
 
-    export class PrincipalViewer extends api.ui.Viewer<Principal> {
-
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class PrincipalViewer extends api.ui.NamesAndIconViewer<Principal> {
 
         private removeClickedListeners: {(event: MouseEvent):void}[] = [];
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).
-                build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(principal: Principal) {
-            super.setObject(principal);
-
-            this.namesAndIconView.setMainName(principal.getDisplayName()).
-                setSubName(this.resolveSubName(principal.getKey())).
-                setIconClass(this.resolveIconClass(principal.getKey()));
+        resolveDisplayName(object: Principal): string {
+            return object.getDisplayName();
         }
 
-        private resolveSubName(key: PrincipalKey): string {
-            return key.toPath();
+        resolveSubName(object: Principal, relativePath: boolean = false): string {
+            return object.getKey().toPath();
         }
 
-        private resolveIconClass(key: PrincipalKey): string {
-            var iconClass;
-            switch (key.getType()) {
-            case PrincipalType.USER:
-                iconClass = "icon-user";
-                break;
-            case PrincipalType.GROUP:
-                iconClass = "icon-users";
-                break;
-            case PrincipalType.ROLE:
-                iconClass = "icon-shield";
-                break;
+        resolveIconClass(object: Principal): string {
+            switch (object.getKey().getType()) {
+                case PrincipalType.USER:
+                    return "icon-user";
+                case PrincipalType.GROUP:
+                    return "icon-users";
+                case PrincipalType.ROLE:
+                    return "icon-shield";
             }
-            return iconClass;
-        }
 
-        getPreferredHeight(): number {
-            return 50;
+            return "";
         }
 
         onRemoveClicked(listener: (event: MouseEvent) => void) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlEntryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlEntryViewer.ts
@@ -1,51 +1,33 @@
 module api.ui.security.acl {
 
     import PrincipalType = api.security.PrincipalType;
-    import PrincipalKey = api.security.PrincipalKey;
-    import UserStoreKey = api.security.UserStoreKey;
     import AccessControlEntry = api.security.acl.AccessControlEntry;
 
-    export class AccessControlEntryViewer extends api.ui.Viewer<AccessControlEntry> {
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class AccessControlEntryViewer extends api.ui.NamesAndIconViewer<AccessControlEntry> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).
-                build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(ace: AccessControlEntry) {
-            super.setObject(ace);
-
-            this.namesAndIconView.setMainName(ace.getPrincipalDisplayName()).
-                setSubName(this.resolveSubName(ace.getPrincipalKey())).
-                setIconClass(this.resolveIconClass(ace.getPrincipalKey()));
+        resolveDisplayName(object: AccessControlEntry): string {
+            return object.getPrincipalDisplayName();
         }
 
-        private resolveSubName(key: PrincipalKey): string {
-            return key.toPath();
+        resolveSubName(object: AccessControlEntry, relativePath: boolean = false): string {
+            return object.getPrincipalKey().toPath();
         }
 
-        private resolveIconClass(key: PrincipalKey): string {
-            var iconClass;
-            switch (key.getType()) {
-            case PrincipalType.USER:
-                iconClass = "icon-user";
-                break;
-            case PrincipalType.GROUP:
-                iconClass = "icon-users";
-                break;
-            case PrincipalType.ROLE:
-                iconClass = "icon-shield";
-                break;
+        resolveIconClass(object: AccessControlEntry): string {
+            switch (object.getPrincipalKey().getType()) {
+                case PrincipalType.USER:
+                    return "icon-user";
+                case PrincipalType.GROUP:
+                    return "icon-users";
+                case PrincipalType.ROLE:
+                    return "icon-shield";
             }
-            return iconClass;
-        }
 
-        getPreferredHeight(): number {
-            return 50;
+            return "";
         }
     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryViewer.ts
@@ -1,39 +1,23 @@
 module api.ui.security.acl {
 
-    import PrincipalType = api.security.PrincipalType;
-    import PrincipalKey = api.security.PrincipalKey;
-    import UserStoreKey = api.security.UserStoreKey;
     import UserStoreAccessControlEntry = api.security.acl.UserStoreAccessControlEntry;
 
-    export class UserStoreAccessControlEntryViewer extends api.ui.Viewer<UserStoreAccessControlEntry> {
-        private namesAndIconView: api.app.NamesAndIconView;
+    export class UserStoreAccessControlEntryViewer extends api.ui.NamesAndIconViewer<UserStoreAccessControlEntry> {
 
         constructor() {
             super();
-            this.namesAndIconView = new api.app.NamesAndIconViewBuilder().
-                setSize(api.app.NamesAndIconViewSize.small).
-                build();
-            this.appendChild(this.namesAndIconView);
         }
 
-        setObject(ace: UserStoreAccessControlEntry) {
-            super.setObject(ace);
-
-            this.namesAndIconView.setMainName(ace.getPrincipalDisplayName()).
-                setSubName(this.resolveSubName(ace.getPrincipalKey())).
-                setIconClass(this.resolveIconClass(ace.getPrincipalKey()));
+        resolveDisplayName(object: UserStoreAccessControlEntry): string {
+            return object.getPrincipalDisplayName();
         }
 
-        private resolveSubName(key: PrincipalKey): string {
-            return key.toPath();
+        resolveSubName(object: UserStoreAccessControlEntry, relativePath: boolean = false): string {
+            return object.getPrincipalKey().toPath();
         }
 
-        private resolveIconClass(key: PrincipalKey): string {
+        resolveIconClass(object: UserStoreAccessControlEntry): string {
             return "icon-users";
-        }
-
-        getPreferredHeight(): number {
-            return 50;
         }
     }
 


### PR DESCRIPTION
Added `NamesAndIconViewer` parent class for the viewers with
`NamesAndIconView`.
Replaced `setHtml()` with the `setText()` in the path and `NameView`.
Updated all the viewers.
Make the viewers to display `<Display Name>`, `<name>` and `<unnamed>`
instead of the empty fields.