### PR TITLE
CMS-5105 Modal windows - Fix newContentDialogue

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
+++ b/modules/admin-ui/src/main/resources/web/admin/common/styles/apps/content/new/new-content-dialog.less
@@ -174,4 +174,14 @@
       }
     }
   }
+
+  &._0-240, &._240-360 {
+    section {
+      width: 100%
+    }
+
+    aside {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
Corresponding styles adjusted to hide "Recently used" column when screen is less then 360px and make another column 100% width