### PR TITLE
CMS-5058 Unnamed - Fix presentation of "Unnamed" in browse lists etc

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/ContentAppPanel.ts
@@ -33,7 +33,7 @@ module app {
             wizardPanel.getHeader().onPropertyChanged((event: api.PropertyChangedEvent) => {
                 if (event.getPropertyName() === "displayName") {
                     var contentType = (<app.wizard.ContentWizardPanel>wizardPanel).getContentType(),
-                        name = <string>event.getNewValue() || "<Unnamed " + contentType.getDisplayName()  + ">";
+                        name = <string>event.getNewValue() || "<Unnamed " + api.util.StringHelper.normalizeAll(contentType.getDisplayName())  + ">";
                     tabMenuItem.setLabel(name, !<string>event.getNewValue());
                 }
             });
@@ -181,7 +181,7 @@ module app {
                             }
 
                             var contentType = (<app.wizard.ContentWizardPanel>wizard).getContentType(),
-                                name = content.getDisplayName() || "<Unnamed " + contentType.getDisplayName()  + ">";
+                                name = content.getDisplayName() || "<Unnamed " + api.util.StringHelper.normalizeAll(contentType.getDisplayName())  + ">";
 
                             tabMenuItem = new AppBarTabMenuItemBuilder().
                                 setLabel(name).
@@ -235,7 +235,7 @@ module app {
                         new api.schema.content.GetContentTypeByNameRequest(content.getType()).
                             sendAndParse().
                             then((contentType: api.schema.content.ContentType) => {
-                                tabMenuItem.setLabel("<Unnamed " + contentType.getDisplayName() + ">", true);
+                                tabMenuItem.setLabel("<Unnamed " + api.util.StringHelper.normalizeAll(contentType.getDisplayName()) + ">", true);
                             }).done();
                     }
 

--- a/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItemViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/user-manager/js/app/browse/UserTreeGridItemViewer.ts
@@ -10,6 +10,11 @@ module app.browse {
             return object.getItemDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: UserTreeGridItem): string {
+            return object.getPrincipal() ? object.getPrincipal().getTypeName()
+                                         : object.getUserStore() ? "User Strore" : "";
+        }
+
         resolveSubName(object: UserTreeGridItem, relativePath: boolean = false): string {
 
             switch (object.getType()) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatusViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryAndCompareStatusViewer.ts
@@ -19,6 +19,11 @@ module api.content {
             return "";
         }
 
+        resolveUnnamedDisplayName(object: ContentSummaryAndCompareStatus): string {
+            var contentSummary = object.getContentSummary();
+            return (contentSummary && contentSummary.getType()) ? contentSummary.getType().getLocalName() : "";
+        }
+
         resolveSubName(object: ContentSummaryAndCompareStatus, relativePath: boolean = false): string {
             var contentSummary = object.getContentSummary(),
                 uploadItem = object.getUploadItem();

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/ContentSummaryViewer.ts
@@ -14,6 +14,10 @@ module api.content {
             return object.getDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: ContentSummary): string {
+            return object.getType() ? object.getType().getLocalName() : "";
+        }
+
         resolveSubName(object: ContentSummary, relativePath: boolean = false): string {
             var contentName = object.getName();
             if (relativePath) {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorDisplayValue.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorDisplayValue.ts
@@ -59,6 +59,10 @@ module api.content.form.inputtype.image {
             return this.content ? this.content.getDisplayName() : null;
         }
 
+        getTypeLocaleName(): string {
+            return (this.content && this.content.getType()) ? this.content.getType().getLocalName() : null;
+        }
+
         getPath(): string {
             return this.content ? this.content.getPath().toString() : null;
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/content/form/inputtype/image/ImageSelectorViewer.ts
@@ -10,6 +10,10 @@ module api.content.form.inputtype.image {
             return object.getDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: ImageSelectorDisplayValue): string {
+            return object.getTypeLocaleName();
+        }
+
         resolveSubName(object: ImageSelectorDisplayValue, relativePath: boolean = false): string {
             return object.getPath();
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/Principal.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/Principal.ts
@@ -46,6 +46,19 @@ module api.security {
             return this.type;
         }
 
+        getTypeName(): string {
+            switch (this.type) {
+                case PrincipalType.GROUP:
+                    return "Group";
+                case PrincipalType.USER:
+                    return "User";
+                case PrincipalType.ROLE:
+                    return "Role";
+                default:
+                    return "";
+            }
+        }
+
         isUser(): boolean {
             return this.type === PrincipalType.USER;
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/acl/AccessControlEntry.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/acl/AccessControlEntry.ts
@@ -34,6 +34,10 @@ module api.security.acl {
             return this.principal.getDisplayName();
         }
 
+        getPrincipalTypeName(): string {
+            return this.principal.getTypeName();
+        }
+
         getAllowedPermissions(): Permission[] {
             return this.allowedPermissions;
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/security/acl/UserStoreAccessControlEntry.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/security/acl/UserStoreAccessControlEntry.ts
@@ -34,6 +34,10 @@ module api.security.acl {
             return this.principal.getDisplayName();
         }
 
+        getPrincipalTypeName(): string {
+            return this.principal.getTypeName();
+        }
+
         equals(o: api.Equitable): boolean {
             if (!api.ObjectHelper.iFrameSafeInstanceOf(o, UserStoreAccessControlEntry)) {
                 return false;

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/NamesAndIconViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/NamesAndIconViewer.ts
@@ -6,7 +6,7 @@ module api.ui {
     export class NamesAndIconViewer<OBJECT> extends api.ui.Viewer<OBJECT> {
 
         static EMPTY_DISPLAY_NAME: string = "<Display Name>";
-        static EMPTY_SUB_NAME: string     = "<name>";
+        static EMPTY_SUB_NAME: string     = "<unnamed>";
 
         private namesAndIconView: api.app.NamesAndIconView;
 
@@ -18,7 +18,7 @@ module api.ui {
         setObject(object: OBJECT, relativePath: boolean = false) {
             super.setObject(object);
 
-            var displayName = this.resolveDisplayName(object) || NamesAndIconViewer.EMPTY_DISPLAY_NAME,
+            var displayName = this.resolveDisplayName(object) || this.normalizeDisplayName(this.resolveUnnamedDisplayName(object)),
                 subName     = this.resolveSubName(object, relativePath) || NamesAndIconViewer.EMPTY_SUB_NAME,
                 subTitle    = this.resolveSubTitle(object),
                 iconClass   = this.resolveIconClass(object),
@@ -34,7 +34,16 @@ module api.ui {
             this.render();
         }
 
+        private normalizeDisplayName(displayName: string): string {
+            return api.util.StringHelper.isEmpty(displayName) ? NamesAndIconViewer.EMPTY_DISPLAY_NAME
+                                                              : "<Unnamed " + api.util.StringHelper.normalizeAll(displayName) + ">";
+        }
+
         resolveDisplayName(object: OBJECT): string {
+            return "";
+        }
+
+        resolveUnnamedDisplayName(object: OBJECT): string {
             return "";
         }
 

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/PrincipalViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/PrincipalViewer.ts
@@ -15,6 +15,10 @@ module api.ui.security {
             return object.getDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: Principal): string {
+            return object.getTypeName();
+        }
+
         resolveSubName(object: Principal, relativePath: boolean = false): string {
             return object.getKey().toPath();
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlEntryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/AccessControlEntryViewer.ts
@@ -13,6 +13,10 @@ module api.ui.security.acl {
             return object.getPrincipalDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: AccessControlEntry): string {
+            return object.getPrincipalTypeName();
+        }
+
         resolveSubName(object: AccessControlEntry, relativePath: boolean = false): string {
             return object.getPrincipalKey().toPath();
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryViewer.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/ui/security/acl/UserStoreAccessControlEntryViewer.ts
@@ -12,6 +12,10 @@ module api.ui.security.acl {
             return object.getPrincipalDisplayName();
         }
 
+        resolveUnnamedDisplayName(object: UserStoreAccessControlEntry): string {
+            return object.getPrincipalTypeName();
+        }
+
         resolveSubName(object: UserStoreAccessControlEntry, relativePath: boolean = false): string {
             return object.getPrincipalKey().toPath();
         }

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/StringHelper.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/StringHelper.ts
@@ -23,7 +23,8 @@ module api.util {
         }
 
         static normalizeAll(str: string): string {
-            return StringHelper.isEmpty(str) ? StringHelper.EMPTY_STRING : StringHelper.capitalizeAll(StringHelper.normalize(str));
+            return StringHelper.isEmpty(str) ? StringHelper.EMPTY_STRING
+                                             : StringHelper.capitalizeAll(StringHelper.normalize(str).toLowerCase());
         }
 
         static isUpperCase(str: string): boolean {

--- a/modules/admin-ui/src/main/resources/web/admin/common/js/util/StringHelper.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/common/js/util/StringHelper.ts
@@ -18,18 +18,26 @@ module api.util {
             });
         }
 
+        static normalize(str: string): string {
+            return StringHelper.isEmpty(str) ? StringHelper.EMPTY_STRING : str.replace(/-/g, " ").trim();
+        }
+
+        static normalizeAll(str: string): string {
+            return StringHelper.isEmpty(str) ? StringHelper.EMPTY_STRING : StringHelper.capitalizeAll(StringHelper.normalize(str));
+        }
+
         static isUpperCase(str: string): boolean {
             if (StringHelper.isEmpty(str)) {
                 return false;
             }
-            return str.toUpperCase() == str;
+            return str.toUpperCase() === str;
         }
 
         static isLowerCase(str: string): boolean {
             if (StringHelper.isEmpty(str)) {
                 return false;
             }
-            return str.toLowerCase() == str;
+            return str.toLowerCase() === str;
         }
 
         static isMixedCase(str: string): boolean {
@@ -40,7 +48,7 @@ module api.util {
         }
 
         static isEmpty(str: string): boolean {
-            return !str || str.length == 0;
+            return !str || str.length === 0;
         }
 
         static isBlank(str: string): boolean {
@@ -92,8 +100,8 @@ module api.util {
          */
         static format(str: string, ...tokens: any[]): string {
             return StringHelper.isEmpty(str) ? StringHelper.EMPTY_STRING : str.replace(/\{\{|\}\}|\{(\d+)\}/g, function (m, n) {
-                if (m == "{{") { return "{"; }
-                if (m == "}}") { return "}"; }
+                if (m === "{{") { return "{"; }
+                if (m === "}}") { return "}"; }
                 return tokens[n];
             });
         }


### PR DESCRIPTION
Populated `StringHelper` with new methods `normalize()` and
`normalizeAll()`  for removing characters with spaces, trimming the
result and capitalizing it afterwards.

Fixed the tab label of the unnamed content.

Replaced `<name>` with unnamed.

Replaced `<Display Name>` with `<Unnamed %item_type%>`.