### PR TITLE
CMS-5152 Preview has stopped working

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/action/PreviewContentAction.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/action/PreviewContentAction.ts
@@ -20,7 +20,7 @@ module app.browse.action {
 
         showPreviewDialog(content: api.content.ContentSummary) {
             window.open(api.rendering.UriHelper.getPortalUri(content.getPath().toString(), RenderingMode.PREVIEW,
-                api.content.Workspace.DRAFT), 'preview');
+                api.content.Workspace.DRAFT), 'preview').focus();
         }
     }
 }


### PR DESCRIPTION
Added focus call for bringing preview window to front, but it may fail due to user settings and the window isn't guaranteed to be frontmost before this method returns.