### PR TITLE
CMS-5171 Upload - html characters visible in status field during upload

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/browse/ContentTreeGrid.ts
@@ -232,11 +232,13 @@ module app.browse {
                 if (!!CompareStatus[value]) {
                     statusEl.addClass(CompareStatus[value].toLowerCase().replace("_", "-") || "unknown");
                 }
+
+                statusEl.getEl().setText(status);
             } else if (!!data.getUploadItem()) {   // uploading node
-                status = new api.ui.ProgressBar(data.getUploadItem().getProgress()).toString();
+                status = new api.ui.ProgressBar(data.getUploadItem().getProgress())
+                statusEl.appendChild(status);
             }
 
-            statusEl.getEl().setText(status);
             return statusEl.toString();
         }
 


### PR DESCRIPTION
Status element was not correctly set in case of uploading - html as pure text was set instead of appending progress bar as a child