### PR TITLE
CMS-5182 Modal window - Modal window often positioned low on first load

### DIFF
--- a/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
+++ b/modules/admin-ui/src/main/resources/web/admin/apps/content-manager/js/app/create/NewContentDialog.ts
@@ -289,7 +289,7 @@ module app.create {
                     this.filterList();
                     this.contentListMask.hide();
                     this.recentListMask.hide();
-
+                    api.ui.responsive.ResponsiveManager.fireResizeEvent();
                 }).done();
         }
 


### PR DESCRIPTION
Reproduced only for new content dialog - when dialog is opened first time it's content types are not yet loaded, so positioning is done over initial size of window, however when data finishes loading size of content div increses what leads to modal window stretching according to css limits; repositioning is required after data loaded.